### PR TITLE
Fixes linux icon

### DIFF
--- a/app/views/downloads.scala.html
+++ b/app/views/downloads.scala.html
@@ -20,7 +20,7 @@
             <p class="lead"><a class="btn btn-lg btn-primary" href="@Home.msiUrl"><i class="glyphicon glyphicon-download"></i> @Home.msiFileName</a></p>
         </div>
         <div class="col-md-5">
-            <h2><i class="glyphicon glyphicon-linux"></i> Linux </h2>
+            <h2><i class="icon-linux"></i> Linux </h2>
             <p>Download DEB: <a class="btn btn-default" href="@Home.debUrl"><i class="glyphicon glyphicon-download"></i> @Home.debFileName</a><p/>
             <p>DEB packages are tested on Ubuntu.</p>
             <p>Download RPM: <a class="btn btn-default" href="@Home.rpmUrl"><i class="glyphicon glyphicon-download"></i> @Home.rpmFileName</a><p/>


### PR DESCRIPTION
The Linux icon on the downloads page was broken after updating to Bootstrap 3.
